### PR TITLE
Tolerate lowercase Kind field in ownerReference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-versions: [1.15.x]
+        go-versions: [1.15.x, 1.16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,8 @@ lint:
 check_go_version:
 	@OUTPUT=`go version`; \
 	case "$$OUTPUT" in \
-	*"go1.13"*);; \
-	*"go1.14"*);; \
 	*"go1.15"*);; \
+	*"go1.16"*);; \
 	*"devel"*);; \
 	*) \
 		echo "Expected: go version go1.13.*, go1.14.*, go1.15.*, or devel"; \

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ build-release: check_go_version
 	mkdir -p ./bin/darwin/amd64
 	mkdir -p ./bin/linux/amd64
 	GOOS=darwin GOARCH=amd64 go build -trimpath -o ./bin/darwin/amd64/kubectl-check-ownerreferences $(shell ./build/print-ldflags.sh) ./
+	GOOS=darwin GOARCH=arm64 go build -trimpath -o ./bin/darwin/arm64/kubectl-check-ownerreferences $(shell ./build/print-ldflags.sh) ./
 	GOOS=linux  GOARCH=amd64 go build -trimpath -o ./bin/linux/amd64/kubectl-check-ownerreferences  $(shell ./build/print-ldflags.sh) ./
 	tar -cvzf ./bin/kubectl-check-ownerreferences-darwin-amd64.tar.gz LICENSE -C ./bin/darwin/amd64 kubectl-check-ownerreferences
+	tar -cvzf ./bin/kubectl-check-ownerreferences-darwin-arm64.tar.gz LICENSE -C ./bin/darwin/arm64 kubectl-check-ownerreferences
 	tar -cvzf ./bin/kubectl-check-ownerreferences-linux-amd64.tar.gz  LICENSE -C ./bin/linux/amd64  kubectl-check-ownerreferences
 
 install: check_go_version

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default install build clean test fmt vet lint
 
+all: build test fmt vet lint
+
 default: build
 
 build: check_go_version

--- a/pkg/verify.go
+++ b/pkg/verify.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/pager"
 )
 
+// VerifyGCOptions contains options controlling how the verify task is run
 type VerifyGCOptions struct {
 	DiscoveryClient discovery.DiscoveryInterface
 	MetadataClient  metadata.Interface
@@ -47,6 +48,7 @@ type VerifyGCOptions struct {
 	Stdout          io.Writer
 }
 
+// Validate ensures the specified options are valid
 func (v *VerifyGCOptions) Validate() error {
 	if v.Output != "" && v.Output != "json" {
 		return fmt.Errorf("invalid output format, only '' and 'json' are supported: %v", v.Output)
@@ -54,6 +56,7 @@ func (v *VerifyGCOptions) Validate() error {
 	return nil
 }
 
+// Run executes the verify operation
 func (v *VerifyGCOptions) Run() error {
 	errorCount := 0
 	warningCount := 0

--- a/pkg/verify.go
+++ b/pkg/verify.go
@@ -252,6 +252,10 @@ func (v *VerifyGCOptions) Run() error {
 						actualOwnerGV, _ := schema.ParseGroupVersion(actualOwner.APIVersion)
 						if actualOwner.Kind == ownerRef.Kind && actualOwnerGV.Group == ownerGV.Group {
 							groupKindOk = true
+						} else if strings.ToLower(actualOwner.Kind) == ownerRef.Kind && actualOwnerGV.Group == ownerGV.Group {
+							// RESTMapper tolerates an all-lowercase kind as input to the lookup
+							// https://github.com/kubernetes/kubernetes/blob/release-1.20/staging/src/k8s.io/client-go/restmapper/discovery.go#L114
+							groupKindOk = true
 						} else {
 							actualGVK = actualOwnerGV.WithKind(actualOwner.Kind)
 						}

--- a/pkg/verify.go
+++ b/pkg/verify.go
@@ -50,6 +50,18 @@ type VerifyGCOptions struct {
 
 // Validate ensures the specified options are valid
 func (v *VerifyGCOptions) Validate() error {
+	if v.DiscoveryClient == nil {
+		return fmt.Errorf("discovery client is required")
+	}
+	if v.MetadataClient == nil {
+		return fmt.Errorf("metadata client is required")
+	}
+	if v.Stderr == nil {
+		return fmt.Errorf("stderr is required")
+	}
+	if v.Stdout == nil {
+		return fmt.Errorf("stdout is required")
+	}
 	if v.Output != "" && v.Output != "json" {
 		return fmt.Errorf("invalid output format, only '' and 'json' are supported: %v", v.Output)
 	}


### PR DESCRIPTION
Avoids false-positive warnings on ownerReferences the garbagecollector actually handles fine

/cc @deads2k 

```
make all
go build -o ./bin/kubectl-check-ownerreferences -ldflags "-X sigs.k8s.io/kubectl-check-ownerreferences/pkg.Version=v0.2.0-8-g4407ecbe83" ./
go test -v ./...
?   	sigs.k8s.io/kubectl-check-ownerreferences	[no test files]
=== RUN   TestVerify
=== RUN   TestVerify/simple
=== RUN   TestVerify/forbidden
=== RUN   TestVerify/unavailable
=== RUN   TestVerify/unavailable_version
=== RUN   TestVerify/mismatched_name
=== RUN   TestVerify/mismatched_kind
=== RUN   TestVerify/cluster_child,_namespaced_owner
=== RUN   TestVerify/mismatched_namespace
=== RUN   TestVerify/multigroup_object
=== RUN   TestVerify/non-preferred_version
=== RUN   TestVerify/case-different_references
--- PASS: TestVerify (0.00s)
    --- PASS: TestVerify/simple (0.00s)
    --- PASS: TestVerify/forbidden (0.00s)
    --- PASS: TestVerify/unavailable (0.00s)
    --- PASS: TestVerify/unavailable_version (0.00s)
    --- PASS: TestVerify/mismatched_name (0.00s)
    --- PASS: TestVerify/mismatched_kind (0.00s)
    --- PASS: TestVerify/cluster_child,_namespaced_owner (0.00s)
    --- PASS: TestVerify/mismatched_namespace (0.00s)
    --- PASS: TestVerify/multigroup_object (0.00s)
    --- PASS: TestVerify/non-preferred_version (0.00s)
    --- PASS: TestVerify/case-different_references (0.00s)
PASS
ok  	sigs.k8s.io/kubectl-check-ownerreferences/pkg	0.513s
gofmt -l ./
go vet ./
golint ./...

```